### PR TITLE
Expand GitHub landing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,178 @@
 # Personal OS + Personal Wiki
 
+[![CI](https://github.com/lawyer112/personal-os-wiki/actions/workflows/ci.yml/badge.svg)](https://github.com/lawyer112/personal-os-wiki/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![Local First](https://img.shields.io/badge/local--first-yes-2ea44f)](#data-safety)
+[![Agent Ready](https://img.shields.io/badge/agent--ready-task%20claiming-blue)](#agent-protocol)
+
 [中文说明](./README.zh-CN.md)
+
+**Category:** local-first agent workbench, Markdown knowledge base, task
+execution protocol.
 
 **Not a second brain. A follow-through engine for humans and agents.**
 
-Personal OS + Personal Wiki turns saved links, voice notes, half-formed ideas,
+Personal OS + Personal Wiki turns saved links, voice notes, rough ideas,
 project updates, and agent output into claimed work with evidence.
 
-Most tools help you capture more. This project is for the harder moment after
-capture, when the real question is:
+Most tools help you collect more. This project is for the harder moment after
+collection:
 
 > What should happen next? Who owns it? What evidence proves it moved?
 
-If your pain is "I saved it, but nothing happened," this is the missing layer:
-a local-first operating loop where humans can think messily and agents can work
-against explicit state instead of guessing from chat history.
-
-This repository gives you a local-first operating loop for humans and agents:
+If your pain is "I saved it, summarized it, and still nothing shipped," this is
+the missing layer: a local-first operating loop where humans can think messily
+and agents work against explicit state instead of guessing from chat history.
 
 ```text
-capture messy input -> compile durable knowledge -> extract executable tasks
-  -> let agents claim work -> review the output -> update the knowledge base
+messy input -> durable wiki memory -> executable tasks
+  -> agent claim -> evidence submission -> human/reviewer approval
+  -> knowledge base updated for the next run
 ```
 
-It is not another passive notebook. It is a small, local command center for:
+## What This Project Is
 
-- capturing rough thoughts, links, transcripts, files, and project updates;
-- turning the durable parts into Markdown Wiki notes;
-- turning the actionable parts into tasks with owners, status, and review gates;
-- giving agents a stable API to poll, claim, execute, heartbeat, and submit;
-- keeping private runtime data outside the public repository.
+Personal OS + Personal Wiki is a local-first workbench for people who want AI
+agents to help them move real projects forward, not just summarize notes.
 
-## Why This Exists
+It gives you three connected layers:
 
-Bookmarks become graveyards. Notes become archives. Chat history becomes fog.
-Agents get smarter, but they still lose context unless the work has a shared
-state machine.
-
-Personal OS + Personal Wiki makes the handoff explicit:
-
-- **Personal Wiki** is the memory: Markdown notes, concepts, tags, backlinks,
-  search, and graph data.
-- **Personal OS** is the work state: Inbox, Ideas, Tasks, Projects, Today,
-  agent runs, task claims, reviews, and notification payloads.
-- **Agent Guide** is the contract: agents do not guess what to do from chat
-  history; they read a manual and call APIs.
-
-The opinionated bet: a useful personal knowledge base should not only remember
-what you saw. It should help decide what is unfinished, what matters next, and
-which agent can push it forward.
-
-## What You Get
-
-- A Next.js + Postgres Personal OS app for inbox, ideas, tasks, projects, and
-  agent task execution.
-- A Python Markdown Wiki with ingest, search, tags, concepts, graph data,
-  browser pages, and read/write token boundaries.
-- Agent-facing APIs for context loading, task claiming, heartbeats,
-  contributions, submission, and review.
-- Local-first defaults: no private vault, database, token, cookie, or server
-  inventory belongs in Git.
-- CI that verifies tests, audit, typecheck, lint, app build, Docker builds, Wiki
-  compile, and secret scanning.
-
-## Components
-
-| Component | Path | Role |
+| Layer | Job | Why it matters |
 | --- | --- | --- |
-| Personal OS | [`personal-os-app/`](./personal-os-app) | Next.js + Postgres workbench for Inbox, Ideas, Tasks, Projects, Today planning, notifications, and agent task execution. |
-| Personal Wiki | [`personal-wiki/`](./personal-wiki) | Python Markdown wiki with ingestion, search, graph data, browser pages, auth handoff, and agent maintenance APIs. |
-| Agent contract | [`docs/AGENT_GUIDE.md`](./docs/AGENT_GUIDE.md) | The operating manual that tells Hermes, Codex, or any other agent how to capture, route, claim, execute, and review work. |
-| Release boundary | [`OPEN_SOURCE_RELEASE.md`](./OPEN_SOURCE_RELEASE.md) | The safety checklist for publishing the software without leaking private data. |
+| **Personal OS** | Inbox, ideas, projects, tasks, today view, agent runs, task claims, reviews, notifications. | This is the execution state. It says what is unfinished, who owns it, and what counts as done. |
+| **Personal Wiki** | Markdown notes, concepts, tags, backlinks, search, graph data, browser pages, sanitized long-term memory. | This is the durable knowledge base. It preserves context without dumping private runtime data into Git. |
+| **Agent Guide** | A written operating manual and API contract for Hermes, Codex, or any other worker agent. | Agents do not improvise from chat history. They read the manual, call APIs, claim work, submit evidence, and wait for review. |
 
-## Architecture In One Picture
+The project is opinionated: a useful personal knowledge base should not only
+remember what you saw. It should expose what is still unfinished and make it
+easy for another agent to push the work forward.
+
+## What You Can Do With It
+
+| Use case | What happens |
+| --- | --- |
+| Save links that usually die in bookmarks | Capture the raw link, summarize it into Wiki memory, and extract follow-up tasks. |
+| Dump "rambling" project thoughts | Preserve the original Inbox item, turn the stable part into knowledge, and turn the actionable part into tasks. |
+| Run several agents against one backlog | Agents poll tasks by tags, claim work, heartbeat while working, submit contributions, and request review. |
+| Keep a private project brain without leaking data | Source code and fake examples go to Git; real vaults, tokens, server inventories, and task history stay local. |
+| Build a revenue/work dashboard | Projects, today view, unfinished tasks, and review queues make "what moves the project" visible. |
+| Use the Wiki as agent memory | Agents can read curated Markdown context instead of relying on stale chat history. |
+
+## Feature Overview
+
+### Personal OS
+
+- Inbox for raw human input and agent observations.
+- Ideas, projects, tasks, notes, activity feed, and Today workspace.
+- Agent-facing task protocol: inbox polling, claim, heartbeat, contribution,
+  submit, review, block, archive.
+- Read and write token boundaries for agent integrations.
+- Planner and notification payloads for daily guidance.
+- Next.js app backed by PostgreSQL and Prisma.
+
+### Personal Wiki
+
+- Markdown vault with browser pages.
+- Ingest API for writing notes from agents or local tools.
+- Search, tags, concepts, graph data, backlinks, and wiki-style navigation.
+- Separate read and write token defaults.
+- Docker-friendly Python service.
+- Compatible with the "Markdown as durable memory" workflow.
+
+### Agent Workflow
+
+Agents use a predictable loop:
+
+```text
+poll -> claim -> load context -> execute -> heartbeat -> contribute -> submit -> review
+```
+
+That loop is the difference between "an agent wrote something in a chat" and
+"a task was claimed, worked, evidenced, and reviewed."
+
+## 10-Minute Demo Path
+
+This is the fastest way to understand the system locally.
+
+### 1. Start Personal Wiki
+
+```bash
+cd personal-wiki
+cp .env.example .env
+docker compose up -d --build
+```
+
+Open:
+
+```text
+http://localhost:3422
+```
+
+### 2. Start Personal OS
+
+```bash
+cd ../personal-os-app
+cp .env.example .env
+docker compose up -d postgres
+npm ci
+npm run prisma:generate
+npm run prisma:migrate
+npm run prisma:seed
+npm run dev
+```
+
+Open:
+
+```text
+http://localhost:3000
+```
+
+For the full OS/Wiki integration, set `WIKI_API_TOKEN` and `WIKI_READ_TOKEN` in
+`personal-os-app/.env` to match `personal-wiki/.env`.
+
+### 3. Try the loop
+
+After seeding, you should see fictional demo data:
+
+| Surface | Demo item |
+| --- | --- |
+| Projects | `Acorn Launch Lab` |
+| Inbox | `Demo input: collect three customer notes...` |
+| Tasks | `Review the fictional launch checklist` |
+| Ideas | `Add a demo screenshot after UI polish` |
+| Notes | `Demo launch checklist` |
+
+Suggested path:
+
+1. Open `Today` to see the current work queue.
+2. Open `Tasks` and inspect `Review the fictional launch checklist`.
+3. Check the next action, definition of done, Wiki link, contribution, and
+   artifact.
+4. Open `Projects` and inspect `Acorn Launch Lab`.
+5. Open `Ideas` and confirm the screenshot idea stayed as an idea instead of
+   being forced into a task.
+
+The full walkthrough is in
+[`docs/GETTING_STARTED.md`](./docs/GETTING_STARTED.md).
+
+## Screenshots
+
+Public screenshots should use fake seed data only. The screenshot capture list
+is tracked in [`docs/assets/screenshots/README.md`](./docs/assets/screenshots/README.md).
+
+Planned captures:
+
+- Today workspace
+- Task review flow
+- Project timeline
+- Agent context panel
+- Wiki note graph
+
+## Architecture
 
 ```text
 Human input
-  |  text, link, file summary, voice transcript, project update
+  |  links, voice transcripts, project notes, file summaries, rough thoughts
   v
 Personal OS /api/intake
   |-- InboxItem: original trace
@@ -101,81 +197,70 @@ Worker agents
 Human or reviewer agent approves, requests changes, blocks, or archives
 ```
 
-The important boundary is simple: Personal OS owns work state. Personal Wiki
-owns durable knowledge. Agents connect the two.
-
-## Human Workflow
-
-1. Drop everything into one intake path: a link, a project concern, a voice
-   note, a server observation, or an unfinished idea.
-2. The intake flow preserves the raw input in Inbox.
-3. Knowledge-worthy material becomes readable Markdown.
-4. Execution-worthy material becomes a task with a next action and definition
-   of done.
-5. Agents poll tasks by tags such as `wiki`, `research`, `coding`, `ops`, or
-   `review`.
-6. Work is not complete just because an agent wrote something. The agent
-   submits evidence, artifacts, and a review request.
-
-## Agent Workflow
-
-Agents should not improvise their own protocol. The minimum execution loop is:
+The important boundary is simple:
 
 ```text
-poll -> claim -> load context -> execute -> heartbeat -> contribute -> submit -> review
+Personal OS   = work state
+Personal Wiki = durable knowledge
+Agent Guide   = portable operating rules
 ```
 
-The full manual is in [`docs/AGENT_GUIDE.md`](./docs/AGENT_GUIDE.md). The lower
-level API reference for Hermes-style integrations is in
-[`personal-os-app/docs/HERMES_API.md`](./personal-os-app/docs/HERMES_API.md).
+Read more:
 
-## Local Development
+- [Architecture](./docs/ARCHITECTURE.md)
+- [Agent Guide](./docs/AGENT_GUIDE.md)
+- [Hermes API contract](./personal-os-app/docs/HERMES_API.md)
 
-Personal OS:
+## Agent Protocol
+
+An agent should not scrape the whole vault or guess from chat history. It should
+follow the contract.
+
+Example task claiming flow:
 
 ```bash
-cd personal-os-app
-cp .env.example .env
-docker compose up -d postgres
-npm ci
-npm run prisma:migrate
-npm run prisma:seed
-npm run dev
+# 1. Poll work
+curl -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  "http://localhost:3000/api/agent-inbox?agentId=research-agent&tags=wiki,research"
+
+# 2. Claim one task
+curl -X POST \
+  -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"research-agent","leaseMinutes":30}' \
+  "http://localhost:3000/api/tasks/<task-id>/claim"
+
+# 3. Load context
+curl -H "Authorization: Bearer $PERSONAL_OS_READ_TOKEN" \
+  "http://localhost:3000/api/agent/context?taskId=<task-id>"
+
+# 4. Submit evidence when done
+curl -X POST \
+  -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"research-agent","summary":"What changed","artifactUrls":["https://example.com/demo"],"evidenceLinks":["wiki://demo/demo-launch-checklist.md"],"definitionOfDoneMet":true,"needsHumanDecision":true}' \
+  "http://localhost:3000/api/tasks/<task-id>/submit"
 ```
 
-Personal Wiki:
+For the complete protocol, read
+[`docs/AGENT_GUIDE.md`](./docs/AGENT_GUIDE.md) and
+[`docs/API_OVERVIEW.md`](./docs/API_OVERVIEW.md).
 
-```bash
-cd personal-wiki
-cp .env.example .env
-docker compose up -d --build
-```
+## What Makes This Different From A Normal Wiki
 
-Default local URLs:
-
-```text
-Personal OS:   http://localhost:3000
-Personal Wiki: http://localhost:3422
-```
-
-## Verification
-
-Run these before publishing or asking another agent to review the package:
-
-```bash
-cd personal-os-app
-npm ci
-npm run prisma:generate
-npm test
-npm audit --omit=dev --audit-level=moderate
-npx tsc --noEmit
-npm run build
-
-cd ../personal-wiki
-python -m py_compile api/server.py
-```
+| Normal note app | This project |
+| --- | --- |
+| Stores notes | Stores knowledge and extracts execution state |
+| Search is the main interface | Tasks, Today, projects, graph, and agent context all matter |
+| AI summarizes content | Agents can claim work and submit reviewable evidence |
+| Links can disappear into an archive | Links can become Wiki pages and follow-up tasks |
+| "Done" means text was written | "Done" means a task was reviewed or explicitly archived |
+| Private data often gets mixed with code | Runtime data is designed to stay outside Git |
 
 ## Data Safety
+
+This repository is the reusable engine, not a dump of a private life or private
+infrastructure.
 
 Safe to commit:
 
@@ -189,38 +274,55 @@ Safe to commit:
 Never commit:
 
 - `.env` files or agent credential exports
-- populated wiki vaults
-- server inventory with private LAN addresses, ports, paths, or business mapping
+- populated Wiki vaults
 - real inbox messages, task history, reminders, or project notes
+- server inventory with private LAN addresses, ports, paths, or business mapping
 - logs, pid files, generated bundles, screenshots, `.next`, `node_modules`
 
-Before pushing to a public repository, run a final secret scan and publish from
-a clean/squashed history that never contained private deployment artifacts.
+Read the full release checklist:
 
-## Repository Strategy
-
-This project should stay as a monorepo while Personal OS, Personal Wiki, and
-the agent protocol are still changing together. Split repositories later only
-if the Wiki becomes independently useful without Personal OS, or if developers
-want to embed only one component.
-
-Detailed strategy:
-
-- [Repository strategy, English](./docs/REPOSITORY_STRATEGY.md)
-- [仓库拆分与开源策略，中文](./docs/REPOSITORY_STRATEGY.zh-CN.md)
-
-## Documentation Map
-
-- [Architecture](./docs/ARCHITECTURE.md)
-- [架构说明](./docs/ARCHITECTURE.zh-CN.md)
-- [Agent guide](./docs/AGENT_GUIDE.md)
-- [Agent 使用手册](./docs/AGENT_GUIDE.zh-CN.md)
+- [Data safety](./docs/DATA_SAFETY.md)
 - [Open source release process](./OPEN_SOURCE_RELEASE.md)
 - [Security policy](./SECURITY.md)
 - [Repository permissions](./docs/PERMISSIONS.md)
-- [Contributing](./CONTRIBUTING.md)
-- [Personal OS README](./personal-os-app/README.md)
-- [Personal Wiki README](./personal-wiki/README.md)
+
+## Documentation Map
+
+| Goal | Read |
+| --- | --- |
+| Understand the product | This README |
+| Run it locally | [Getting Started](./docs/GETTING_STARTED.md) |
+| Understand architecture | [Architecture](./docs/ARCHITECTURE.md) |
+| Connect an agent | [Agent Guide](./docs/AGENT_GUIDE.md), [API Overview](./docs/API_OVERVIEW.md), and [Hermes API](./personal-os-app/docs/HERMES_API.md) |
+| Operate Personal OS | [Personal OS README](./personal-os-app/README.md) |
+| Operate Personal Wiki | [Personal Wiki README](./personal-wiki/README.md) and [Wiki usage](./personal-wiki/docs/USAGE.md) |
+| Understand data safety | [Data safety](./docs/DATA_SAFETY.md) |
+| Publish safely | [Open source release process](./OPEN_SOURCE_RELEASE.md) |
+| Decide monorepo vs split repos | [Repository strategy](./docs/REPOSITORY_STRATEGY.md) |
+| See what is next | [Roadmap](./docs/ROADMAP.md) |
+
+## Roadmap
+
+The short version:
+
+- Improve public screenshots and the browser walkthrough.
+- Add more agent task-claiming examples and smoke scripts.
+- Improve task extraction from messy input.
+- Add richer project dashboards and priority views.
+- Explore Wiki graph insights and knowledge-gap detection.
+
+Read the full [roadmap](./docs/ROADMAP.md).
+
+## Limitations And Maturity
+
+- This is not a hosted SaaS product.
+- This is not a multi-tenant organization system.
+- Built-in auth is token based; public deployments should sit behind an
+  authenticated reverse proxy.
+- Runtime data is not encrypted by the app itself.
+- Agents cannot bypass review by design, but bad submissions still require
+  human or reviewer-agent judgment.
+- The first-run demo is intentionally fake and small.
 
 ## Project Status
 
@@ -228,3 +330,14 @@ This is an early public release. It is useful for builders who want to study or
 adapt a local-first agent workbench, but it is not a hosted SaaS product and it
 does not include your private knowledge base. Treat it as an engine, not as a
 cloud service.
+
+## Contributing
+
+Contributions are welcome if they keep the same boundary:
+
+- do not add real private data;
+- keep local-first defaults safe;
+- document API behavior when changing agent-facing routes;
+- add or update tests for execution-state changes.
+
+Start with [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,175 +1,90 @@
 # Personal OS + Personal Wiki
 
+[![CI](https://github.com/lawyer112/personal-os-wiki/actions/workflows/ci.yml/badge.svg)](https://github.com/lawyer112/personal-os-wiki/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![Local First](https://img.shields.io/badge/local--first-yes-2ea44f)](#数据安全)
+[![Agent Ready](https://img.shields.io/badge/agent--ready-task%20claiming-blue)](#agent-协议)
+
 [English README](./README.md)
+
+**项目类型：** 本地优先 Agent 工作台、Markdown 知识库、任务执行协议。
 
 **不是第二大脑，是推进引擎。**
 
-Personal OS + Personal Wiki 把收藏夹、碎碎念、语音转写、项目进展和 Agent 产物，变成有人认领、有人验收、有证据链的任务。
+Personal OS + Personal Wiki 把收藏夹、语音转写、碎碎念、项目进展和 Agent 产物，变成有人认领、有人提交证据、有人复核的任务。
 
-很多工具只解决“存下来”。这个项目解决的是存下来之后更难的部分：
+大多数工具帮你“存下来”。这个项目处理的是存下来之后真正困难的部分：
 
-> 接下来该做什么？谁来做？做到什么程度才算真的推进了？
+> 接下来该做什么？谁负责？做到什么程度才算真的推进了？
 
-如果你的痛点是“我收藏了、记录了、也让 Agent 总结了，但最后还是没有产出”，那这里补的是中间缺失的一层：一个本地优先的推进闭环。人可以说得很乱，Agent 不能靠猜，它要面对明确的状态、任务和验收口径工作。
-
-Personal OS + Personal Wiki 是一套本地优先的个人工作系统：
+如果你的痛点是“我收藏了、总结了、让 Agent 看过了，但最后还是没有产出”，那这里补的是中间缺失的一层：一个本地优先的推进闭环。人可以说得很乱，Agent 不能靠猜，它要面对明确的状态、任务和验收口径工作。
 
 ```text
-碎片输入 -> 沉淀成 Wiki 知识 -> 抽取可执行任务
-  -> Agent 认领执行 -> 人或 Reviewer 复核 -> 结果回写知识库
+碎片输入 -> Wiki 长期记忆 -> 可执行任务
+  -> Agent 认领 -> 提交证据 -> 人或 Reviewer 复核
+  -> 结果回写知识库，供下一轮继续使用
 ```
 
-它不是又一个被动笔记软件。它更像一个给你和 Agent 共用的小型作战室：
+## 这是什么
 
-- 你可以随手丢链接、想法、文件摘要、语音转写、项目更新；
-- 值得长期保存的内容进入 Markdown Wiki；
-- 需要行动的内容进入任务系统，并带有状态、负责人和验收口径；
-- Agent 通过 API 拉任务、认领、心跳续约、提交产物、等待复核；
-- 真实 vault、数据库、token、服务器台账和私人任务都不进公开仓库。
+Personal OS + Personal Wiki 是一个本地优先的个人工作台，用来让 AI Agent 不只是总结笔记，而是真的帮助你推进项目。
 
-## 为什么做这个
+它由三层组成：
 
-收藏夹会吃灰，笔记会变成档案馆，聊天记录会变成雾。Agent 能力越来越强，但如果没有共同的任务状态和证据链，它还是会靠上下文猜，今天说一套，明天又跑偏。
-
-这个项目把边界拆清楚：
-
-- **Personal Wiki 是记忆**：Markdown 笔记、概念、标签、双链、搜索、图谱。
-- **Personal OS 是工作状态**：Inbox、Ideas、Tasks、Projects、Today、AgentRun、任务认领、复核和通知 payload。
-- **Agent Guide 是合约**：Agent 不靠聊天记录猜流程，而是先读手册，再按 API 工作。
-
-这个项目的核心判断是：个人知识库不应该只帮你记住“看过什么”，还应该帮你判断“什么还没完成、下一步是什么、哪个 Agent 能把它往前顶”。
-
-## 你能得到什么
-
-- 一个 Next.js + Postgres 的 Personal OS：管理 Inbox、想法、任务、项目和 Agent 执行。
-- 一个 Python Markdown Wiki：支持入库、搜索、标签、概念、图谱、浏览器页面和读写 token 边界。
-- 一套面向 Agent 的任务协议：context、claim、heartbeat、contribution、submit、review。
-- 本地优先的安全默认值：私人 vault、数据库、token、cookie、服务器台账都不属于 Git。
-- 一套 CI：测试、依赖审计、类型检查、lint、Next build、Docker build、Wiki 编译和 secret scan。
-
-## 两个核心组件
-
-| 组件 | 路径 | 负责什么 |
+| 层 | 负责什么 | 为什么重要 |
 | --- | --- | --- |
-| Personal OS | [`personal-os-app/`](./personal-os-app) | Inbox、Ideas、Tasks、Projects、Today、AgentRun、任务认领、产物提交、通知 payload。 |
-| Personal Wiki | [`personal-wiki/`](./personal-wiki) | Markdown vault、入库、搜索、标签、概念、图谱、浏览器页面、Wiki 维护 API。 |
-| Agent 手册 | [`docs/AGENT_GUIDE.zh-CN.md`](./docs/AGENT_GUIDE.zh-CN.md) | 告诉 Hermes、Codex、OpenClaw 或其他 Agent 怎么读、写、认领和复核任务。 |
-| 开源边界 | [`OPEN_SOURCE_RELEASE.md`](./OPEN_SOURCE_RELEASE.md) | 说明哪些能发 GitHub，哪些必须留在本地。 |
+| **Personal OS** | Inbox、Ideas、Projects、Tasks、Today、AgentRun、任务认领、复核、通知。 | 这是执行状态层。它回答什么没完成、谁负责、做到什么算完成。 |
+| **Personal Wiki** | Markdown 笔记、概念、标签、双链、搜索、图谱、浏览页面、长期记忆。 | 这是知识层。它保留上下文，但不把真实运行数据混进公开仓库。 |
+| **Agent Guide** | 给 Hermes、Codex 或其他 worker agent 看的操作手册和 API 合约。 | Agent 不靠聊天记录猜流程，而是读手册、调接口、认领任务、提交证据、等待复核。 |
 
-## 系统边界
+这个项目的核心判断是：个人知识库不应该只帮你记住“看过什么”，还应该暴露“什么还没完成”，并让另一个 Agent 能接着往前顶。
 
-Personal OS 不是知识库，Personal Wiki 也不是任务系统。它们的分工应该固定下来：
+## 它能做什么
 
-```text
-Personal OS = 工作状态
-- 原始输入
-- 想法池
-- 今天任务
-- 项目状态
-- Agent 运行记录
-- 任务认领和复核
-- 通知内容
+| 场景 | 系统会怎么处理 |
+| --- | --- |
+| 收藏夹里很多链接长期吃灰 | 保留原始链接，沉淀 Wiki 摘要，并抽取后续任务。 |
+| 你说了一堆项目碎碎念 | 原文进入 Inbox，稳定结论进 Wiki，可执行动作进 Task。 |
+| 多个 Agent 扫同一个任务池 | Agent 按标签拉任务、认领、心跳续约、提交进展、等待复核。 |
+| 想要私有项目大脑但又要开源代码 | 源码和虚构 demo 可以进 Git，真实 vault、token、服务器台账和任务历史留在本地。 |
+| 想把知识库服务于挣钱和项目推进 | Projects、Today、未完成任务和 Review 队列让“什么能推动项目”变得可见。 |
+| 想把 Wiki 当成 Agent 记忆 | Agent 读取整理过的 Markdown 上下文，而不是依赖过期聊天记录。 |
 
-Personal Wiki = 长期知识
-- Markdown 笔记
-- 标签和概念
-- 双链和图谱
-- 手册和教程
-- 证据、结论、项目背景
-```
+## 功能概览
 
-Agent 的职责是把两边连起来：先查 Personal OS 任务，再读取 Personal Wiki 上下文，然后执行，最后把结果写回任务和知识库。
+### Personal OS
 
-## 核心流程
+- Inbox：保留原始输入和 Agent 观察。
+- Ideas、Projects、Tasks、Notes、Activity、Today 工作台。
+- Agent 任务协议：拉任务、认领、心跳、写贡献、提交、复核、阻塞、归档。
+- 面向 Agent 的读写 token 边界。
+- 日计划和通知 payload。
+- Next.js + PostgreSQL + Prisma。
 
-```text
-用户输入
-  |  链接、语音转写、项目想法、服务器观察、临时吐槽
-  v
-Personal OS /api/intake
-  |-- InboxItem：保留原始输入
-  |-- Idea：还没成熟的想法
-  |-- Task：可执行下一步
-  |-- ProjectEvent：项目进展记录
-  |-- AgentRun：Agent 当时怎么判断
-  |
-  +--> Personal Wiki /api/ingest
-       |-- Markdown 笔记
-       |-- 标签和概念
-       |-- 搜索索引
-       |-- 图谱关系
+### Personal Wiki
 
-其他 Agent
-  |-- /api/agent-inbox 拉取任务
-  |-- /api/tasks/:id/claim 认领任务
-  |-- /api/agent/context 读取上下文
-  |-- /api/tasks/:id/heartbeat 执行中心跳续约
-  |-- /api/tasks/:id/contributions 写进展
-  |-- /api/tasks/:id/submit 提交复核
-  v
-人或 Reviewer Agent 审核：通过、打回、阻塞、归档
-```
+- Markdown vault 和浏览器页面。
+- Agent 或本地工具可调用的入库 API。
+- 搜索、标签、概念、图谱、双链和 Wiki 导航。
+- 默认区分读 token 和写 token。
+- Python 服务，可用 Docker 启动。
+- 兼容“Markdown 作为长期记忆”的工作流。
 
-## 人怎么用
+### Agent 工作流
 
-你不需要一开始就把话说得很结构化。正常用法应该是：
-
-- 看到一个链接，发进去。
-- 想到一个项目方向，发进去。
-- 今天很迷茫，直接说卡在哪里。
-- 某台机器发现一个服务，发进去。
-- 一个 Agent 做完事，把产物链接和判断发进去。
-
-系统要做的不是复述你的话，而是拆成：
-
-- `Inbox`：原始记录
-- `Wiki`：长期知识
-- `Task`：下一步动作
-- `Project`：属于哪个项目
-- `Review`：哪些需要你拍板
-
-任务文案必须说人话，格式接近：
+Agent 使用固定循环：
 
 ```text
-动词 + 对象 + 验收结果
+poll -> claim -> load context -> execute -> heartbeat -> contribute -> submit -> review
 ```
 
-例如：
+这个循环的意义是：不是“Agent 在聊天里写了一段话”，而是“任务被认领、执行、提交证据，并进入复核”。
 
-- 不要写：整理 Wiki
-- 应该写：给 3 篇孤立的项目笔记补上“目标、当前状态、下一步、相关任务”四个小节
+## 10 分钟 Demo
 
-## Agent 怎么用
+这是最快理解系统的方式。
 
-Agent 不应该只靠聊天上下文猜。它应该先读手册，再按 API 工作：
-
-- [Agent 使用手册](./docs/AGENT_GUIDE.zh-CN.md)
-- [Agent Guide](./docs/AGENT_GUIDE.md)
-- [Hermes API 合约](./personal-os-app/docs/HERMES_API.md)
-
-最小任务执行循环：
-
-```text
-poll -> claim -> context -> execute -> heartbeat -> contribute -> submit -> review
-```
-
-也就是说，Agent 不是“看见任务就偷偷改完”。它要先认领，执行期间保持心跳，提交证据和产物，然后进入复核。
-
-## 本地开发
-
-Personal OS：
-
-```bash
-cd personal-os-app
-cp .env.example .env
-docker compose up -d postgres
-npm ci
-npm run prisma:migrate
-npm run prisma:seed
-npm run dev
-```
-
-Personal Wiki：
+### 1. 启动 Personal Wiki
 
 ```bash
 cd personal-wiki
@@ -177,29 +92,148 @@ cp .env.example .env
 docker compose up -d --build
 ```
 
-默认地址：
+打开：
 
 ```text
-Personal OS:   http://localhost:3000
-Personal Wiki: http://localhost:3422
+http://localhost:3422
 ```
 
-## 验证命令
+### 2. 启动 Personal OS
 
 ```bash
 cd personal-os-app
+cp .env.example .env
+docker compose up -d postgres
 npm ci
 npm run prisma:generate
-npm test
-npm audit --omit=dev --audit-level=moderate
-npx tsc --noEmit
-npm run build
-
-cd ../personal-wiki
-python -m py_compile api/server.py
+npm run prisma:migrate
+npm run prisma:seed
+npm run dev
 ```
 
-## GitHub 发布边界
+打开：
+
+```text
+http://localhost:3000
+```
+
+### 3. 看 demo 闭环
+
+seed 后你会看到一组虚构数据：
+
+| 页面 | demo 内容 |
+| --- | --- |
+| Projects | `Acorn Launch Lab` |
+| Inbox | `Demo input: collect three customer notes...` |
+| Tasks | `Review the fictional launch checklist` |
+| Ideas | `Add a demo screenshot after UI polish` |
+| Notes | `Demo launch checklist` |
+
+建议点击路径：
+
+1. 打开 `Today`，看当前任务队列。
+2. 打开 `Tasks`，进入 `Review the fictional launch checklist`。
+3. 查看下一步动作、完成定义、Wiki 链接、贡献记录和 artifact。
+4. 打开 `Projects`，查看 `Acorn Launch Lab` 如何串起任务和知识。
+5. 打开 `Ideas`，确认不成熟想法不会被硬转成任务。
+
+完整教程见：
+
+- [快速上手](./docs/GETTING_STARTED.zh-CN.md)
+- [Getting Started](./docs/GETTING_STARTED.md)
+
+## 架构图
+
+```text
+用户输入
+  |  链接、语音转写、项目想法、文件摘要、临时吐槽
+  v
+Personal OS /api/intake
+  |-- InboxItem: 原始记录
+  |-- Idea: 还没成熟的想法
+  |-- Task: 可执行下一步
+  |-- ProjectEvent: 项目时间线
+  |-- AgentRun: Agent 当时怎么判断
+  |
+  +--> Personal Wiki /api/ingest
+       |-- Markdown 笔记
+       |-- 标签和概念
+       |-- 搜索索引
+       |-- 图谱关系
+
+Worker Agent
+  |-- poll /api/agent-inbox
+  |-- claim /api/tasks/:id/claim
+  |-- read /api/agent/context
+  |-- heartbeat while working
+  |-- submit contribution and artifacts
+  v
+人或 Reviewer Agent 审核：通过、打回、阻塞、归档
+```
+
+边界很简单：
+
+```text
+Personal OS   = 工作状态
+Personal Wiki = 长期知识
+Agent Guide   = 可移植操作规则
+```
+
+更多说明：
+
+- [架构说明](./docs/ARCHITECTURE.zh-CN.md)
+- [Agent 使用手册](./docs/AGENT_GUIDE.zh-CN.md)
+- [Hermes API 合约](./personal-os-app/docs/HERMES_API.md)
+
+## Agent 协议
+
+Agent 不应该扫描整个 vault，也不应该靠聊天记录猜。它应该遵守协议。
+
+最小任务认领流程：
+
+```bash
+# 1. 拉取任务
+curl -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  "http://localhost:3000/api/agent-inbox?agentId=research-agent&tags=wiki,research"
+
+# 2. 认领任务
+curl -X POST \
+  -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"research-agent","leaseMinutes":30}' \
+  "http://localhost:3000/api/tasks/<task-id>/claim"
+
+# 3. 读取上下文
+curl -H "Authorization: Bearer $PERSONAL_OS_READ_TOKEN" \
+  "http://localhost:3000/api/agent/context?taskId=<task-id>"
+
+# 4. 完成后提交证据
+curl -X POST \
+  -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"research-agent","summary":"What changed","artifactUrls":["https://example.com/demo"],"evidenceLinks":["wiki://demo/demo-launch-checklist.md"],"definitionOfDoneMet":true,"needsHumanDecision":true}' \
+  "http://localhost:3000/api/tasks/<task-id>/submit"
+```
+
+完整协议见：
+
+- [Agent 使用手册](./docs/AGENT_GUIDE.zh-CN.md)
+- [API 总览](./docs/API_OVERVIEW.md)
+
+## 和普通 Wiki 有什么区别
+
+| 普通笔记工具 | 这个项目 |
+| --- | --- |
+| 主要存笔记 | 同时存知识和执行状态 |
+| 搜索是主要入口 | Tasks、Today、Projects、Graph、Agent Context 都是入口 |
+| AI 负责总结 | Agent 可以认领任务并提交可复核证据 |
+| 链接容易变成档案 | 链接可以变成 Wiki 页面和后续任务 |
+| 写完文字就像完成 | 任务要复核通过或明确归档才算闭环 |
+| 私有数据容易和代码混在一起 | 运行数据设计上不进 Git |
+
+## 数据安全
+
+这个仓库是可复用引擎，不是私人生活或私有基础设施的备份。
 
 可以提交：
 
@@ -207,50 +241,64 @@ python -m py_compile api/server.py
 - 测试
 - 文档
 - `.env.example`
-- Docker/compose 示例
+- 使用占位值的 Docker / compose 文件
 - 虚构 demo 数据
 
 不能提交：
 
-- `.env`
-- token、cookie、SSH key、agent env
+- `.env` 或 agent credential export
 - 真实 Wiki vault
-- 真实服务器台账、内网 IP、端口、路径、业务映射
 - 真实 Inbox、任务、提醒事项、项目历史
-- 日志、截图、pid、zip、`.next`、`node_modules`
+- 包含内网地址、端口、路径、业务映射的服务器台账
+- 日志、pid、构建产物、截图、`.next`、`node_modules`
 
-详细清单见 [`OPEN_SOURCE_RELEASE.md`](./OPEN_SOURCE_RELEASE.md)。
+更多安全边界：
 
-## Wiki 是否要单独开仓库
-
-当前建议：先不要拆，先保持一个 monorepo。
-
-原因很直接：现在 Personal OS、Personal Wiki、Agent 协议还在一起演化。任务认领、上下文读取、Wiki 入库、通知 payload、cookie handoff 都是联动设计。过早拆仓会让安装、文档和 review 成本变高。
-
-什么时候可以拆：
-
-- Personal Wiki 可以脱离 Personal OS 独立安装、独立使用。
-- 有开发者只想用 Wiki，不想用 OS。
-- API 合约稳定，不再频繁一起改。
-- CI、Docker、文档和 demo 都能分别跑通。
-
-详细策略见：
-
-- [Repository Strategy](./docs/REPOSITORY_STRATEGY.md)
-- [仓库拆分与开源策略](./docs/REPOSITORY_STRATEGY.zh-CN.md)
+- [数据安全](./docs/DATA_SAFETY.zh-CN.md)
+- [Open source release process](./OPEN_SOURCE_RELEASE.md)
+- [Security policy](./SECURITY.md)
+- [Repository permissions](./docs/PERMISSIONS.md)
 
 ## 文档地图
 
-- [架构说明](./docs/ARCHITECTURE.zh-CN.md)
-- [Architecture](./docs/ARCHITECTURE.md)
-- [Agent 使用手册](./docs/AGENT_GUIDE.zh-CN.md)
-- [Agent Guide](./docs/AGENT_GUIDE.md)
-- [仓库拆分与开源策略](./docs/REPOSITORY_STRATEGY.zh-CN.md)
-- [Open Source Release Process](./OPEN_SOURCE_RELEASE.md)
-- [Security Policy](./SECURITY.md)
-- [Repository Permissions](./docs/PERMISSIONS.md)
-- [Contributing](./CONTRIBUTING.md)
+| 目标 | 阅读 |
+| --- | --- |
+| 理解项目 | 本 README |
+| 本地跑起来 | [快速上手](./docs/GETTING_STARTED.zh-CN.md) |
+| 理解架构 | [架构说明](./docs/ARCHITECTURE.zh-CN.md) |
+| 接入 Agent | [Agent 使用手册](./docs/AGENT_GUIDE.zh-CN.md) 和 [API 总览](./docs/API_OVERVIEW.md) |
+| 使用 Personal OS | [Personal OS README](./personal-os-app/README.md) |
+| 使用 Personal Wiki | [Personal Wiki README](./personal-wiki/README.md) 和 [Wiki 使用手册](./personal-wiki/docs/USAGE.md) |
+| 安全发布 | [Open source release process](./OPEN_SOURCE_RELEASE.md) |
+| 判断是否拆仓 | [仓库拆分与开源策略](./docs/REPOSITORY_STRATEGY.zh-CN.md) |
 
-## 当前状态
+## 路线图
+
+短期：
+
+- 补更完整的首轮 demo 截图和浏览器导览。
+- 增加 Agent 认领、提交、复核的更多示例。
+- 增加更多通知适配器。
+- 改进任务抽取和“说人话”的任务文案。
+
+中期：
+
+- 更强的项目看板和收入/产出优先级视图。
+- Agent 按能力标签自我认领任务。
+- Wiki 图谱洞察和知识缺口发现。
+- 更安全的个人 vault 导入导出流程。
+
+## 项目状态
 
 这是一个早期公开版本。它适合给想研究或改造“本地优先 Agent 工作台”的开发者看，但它不是云服务，也不包含你的私人知识库。请把它当作一个可复用引擎，而不是直接托管好的产品。
+
+## 贡献
+
+欢迎贡献，但要保持边界：
+
+- 不加入真实私人数据；
+- 保持本地优先和安全默认值；
+- 改 agent-facing API 时同步更新文档；
+- 修改执行状态相关逻辑时补测试。
+
+从 [CONTRIBUTING.md](./CONTRIBUTING.md) 开始。

--- a/docs/API_OVERVIEW.md
+++ b/docs/API_OVERVIEW.md
@@ -1,0 +1,152 @@
+# API Overview
+
+This document is the short, copyable API map. The full Hermes-style contract is
+in [`../personal-os-app/docs/HERMES_API.md`](../personal-os-app/docs/HERMES_API.md).
+
+## Authentication
+
+Personal OS uses bearer tokens.
+
+| Token | Used for |
+| --- | --- |
+| `PERSONAL_OS_API_TOKEN` | Mutating routes and agent execution routes. |
+| `PERSONAL_OS_READ_TOKEN` | Read-only context and workspace routes. |
+
+Personal Wiki uses separate read and write tokens.
+
+| Token | Used for |
+| --- | --- |
+| `WIKI_API_TOKEN` | Writing notes through ingest/update APIs. |
+| `WIKI_READ_TOKEN` | Reading private Wiki pages and APIs. |
+
+Do not put write tokens in browser URLs, screenshots, logs, or public docs.
+
+## Minimal Personal OS Calls
+
+Read the Today workspace:
+
+```bash
+curl -H "Authorization: Bearer $PERSONAL_OS_READ_TOKEN" \
+  http://localhost:3000/api/today
+```
+
+Capture mixed input:
+
+```bash
+curl -X POST http://localhost:3000/api/intake \
+  -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "manual",
+      "sourcePlatform": "demo",
+      "rawText": "Demo input: compare the agent queue with my current workflow.",
+      "createdBy": "user"
+    },
+    "agent": {
+      "model": "example-agent-model",
+      "reasoningSummary": "Classified demo input as one follow-up task."
+    },
+    "tasks": [
+      {
+        "title": "Compare the demo agent queue with my workflow",
+        "status": "todo",
+        "priority": "P2",
+        "riskLevel": "low",
+        "agentTags": ["demo", "review"],
+        "nextAction": "Write one paragraph with the biggest gap.",
+        "definitionOfDone": "A review note is attached to the task."
+      }
+    ]
+  }'
+```
+
+Poll work for an agent:
+
+```bash
+curl -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  "http://localhost:3000/api/agent-inbox?agentId=demo-agent&tags=demo,review"
+```
+
+Claim a task:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"demo-agent","leaseMinutes":30}' \
+  "http://localhost:3000/api/tasks/<task-id>/claim"
+```
+
+Load context for a task:
+
+```bash
+curl -H "Authorization: Bearer $PERSONAL_OS_READ_TOKEN" \
+  "http://localhost:3000/api/agent/context?taskId=<task-id>"
+```
+
+Submit evidence:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $PERSONAL_OS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "demo-agent",
+    "summary": "Compared the queue with the workflow and attached findings.",
+    "artifactUrls": ["https://example.com/demo-artifact"],
+    "evidenceLinks": ["wiki://demo/demo-launch-checklist.md"],
+    "definitionOfDoneMet": true,
+    "needsHumanDecision": true
+  }' \
+  "http://localhost:3000/api/tasks/<task-id>/submit"
+```
+
+## Endpoint Matrix
+
+| Purpose | Endpoint | Method | Token |
+| --- | --- | --- | --- |
+| Read Today workspace | `/api/today` | `GET` | `PERSONAL_OS_READ_TOKEN` |
+| Capture mixed input | `/api/intake` | `POST` | `PERSONAL_OS_API_TOKEN` |
+| Agent polls work | `/api/agent-inbox` | `GET` | `PERSONAL_OS_API_TOKEN` |
+| Agent loads context | `/api/agent/context?taskId=...` | `GET` | `PERSONAL_OS_READ_TOKEN` |
+| Agent claims work | `/api/tasks/:id/claim` | `POST` | `PERSONAL_OS_API_TOKEN` |
+| Agent heartbeats | `/api/tasks/:id/heartbeat` | `POST` | `PERSONAL_OS_API_TOKEN` |
+| Agent contributes progress | `/api/tasks/:id/contributions` | `POST` | `PERSONAL_OS_API_TOKEN` |
+| Agent submits work | `/api/tasks/:id/submit` | `POST` | `PERSONAL_OS_API_TOKEN` |
+| Reviewer decides | `/api/tasks/:id/review` | `POST` | `PERSONAL_OS_API_TOKEN` |
+| Wiki ingest | `Personal Wiki /api/ingest` | `POST` | `WIKI_API_TOKEN` |
+
+## Response Shape
+
+Most JSON APIs return:
+
+```json
+{
+  "ok": true
+}
+```
+
+Errors use:
+
+```json
+{
+  "ok": false,
+  "error": "Missing or invalid API token"
+}
+```
+
+Validation errors include an `issues` array.
+
+## Agent State Contract
+
+Agents should treat the Personal OS task record as the source of truth:
+
+- Claim before working.
+- Keep the lease alive with heartbeat if work takes time.
+- Attach evidence and artifact URLs.
+- Submit for review instead of silently marking work done.
+- Let a human or reviewer agent approve, reject, block, or archive.
+
+This is intentionally stricter than a chat workflow. It makes agent work
+auditable and resumable.

--- a/docs/DATA_SAFETY.md
+++ b/docs/DATA_SAFETY.md
@@ -1,0 +1,95 @@
+# Data Safety
+
+Personal OS + Personal Wiki is local-first, but "local-first" does not
+automatically mean "safe." This document explains what data exists, where it
+lives, and what must stay out of public Git history.
+
+## Data Classes
+
+| Data | Stored in | Public Git? | Notes |
+| --- | --- | --- | --- |
+| Application source | Repository | Yes | Code, tests, docs, migrations, templates. |
+| Fake demo data | Repository seed files | Yes | Must be obviously fictional. |
+| Inbox items | PostgreSQL | No | Raw user text can contain private intent. |
+| Tasks and project state | PostgreSQL | No | Reveals priorities, plans, and unfinished work. |
+| Agent runs and reasoning summaries | PostgreSQL | No | May reveal private decision traces. |
+| Wiki notes | Markdown vault | No by default | Publish only sanitized example notes. |
+| Tokens and credentials | `.env` / secret store | Never | Use `.env.example` placeholders only. |
+| Server inventory | Private vault/docs | Never | Private IPs, ports, paths, and business mapping are sensitive. |
+| Logs and screenshots | Runtime files | No | Can contain URLs, tokens, file paths, or private text. |
+
+## Runtime Storage
+
+Personal OS stores execution state in PostgreSQL:
+
+- Inbox items
+- Ideas
+- Tasks
+- Projects
+- Notes
+- Agent runs
+- Task claims
+- Contributions
+- Reviews
+- Activity events
+- Notification payloads
+
+Personal Wiki stores durable knowledge in a Markdown vault and JSON indexes:
+
+- Markdown notes
+- Tags and concepts
+- Search index data
+- Graph data
+- Archived notes
+
+The public repository should contain the software engine, not populated runtime
+state.
+
+## Token Boundaries
+
+Use separate read and write tokens:
+
+- `PERSONAL_OS_API_TOKEN` for mutating Personal OS routes.
+- `PERSONAL_OS_READ_TOKEN` for read-only Personal OS routes.
+- `WIKI_API_TOKEN` for Wiki writes.
+- `WIKI_READ_TOKEN` for Wiki reads and browser handoff.
+
+Do not fall back from read token to write token for browser cookies. Do not put
+tokens in URLs. Do not paste real tokens into issues, screenshots, examples, or
+agent prompts.
+
+## Backups
+
+Back up runtime state separately from source code:
+
+- PostgreSQL dumps for Personal OS state.
+- Markdown vault backups for Personal Wiki.
+- `.env` and deployment secrets in a password manager or secret manager.
+
+Do not store real backups in the public repository.
+
+## Scrubbing Before Public Release
+
+Before publishing or opening a PR from a private working tree:
+
+1. Confirm `.env`, vault data, logs, screenshots, dumps, and generated bundles
+   are ignored.
+2. Run the CI secret/private-data scan.
+3. Search for private network ranges, real domains, usernames, and deployment
+   paths.
+4. Review demo data manually.
+5. Publish from clean history if private artifacts ever existed in old commits.
+
+See [`../OPEN_SOURCE_RELEASE.md`](../OPEN_SOURCE_RELEASE.md) for the full
+release checklist.
+
+## Current Limitations
+
+- Runtime data is not encrypted by the app itself; use disk, database, and host
+  security controls.
+- This release is not a multi-tenant SaaS system.
+- Built-in auth is token based; put public deployments behind an authenticated
+  reverse proxy.
+- Agent autonomy is constrained by the task protocol, but a bad agent can still
+  submit bad output. Review gates matter.
+- Deleting public Git history after a leak is not enough; rotate exposed tokens.

--- a/docs/DATA_SAFETY.zh-CN.md
+++ b/docs/DATA_SAFETY.zh-CN.md
@@ -1,0 +1,84 @@
+# 数据安全
+
+Personal OS + Personal Wiki 是本地优先，但“本地优先”不等于自动安全。这份文档说明哪些数据存在、存在哪里、哪些绝不能进入公开 Git 历史。
+
+## 数据分类
+
+| 数据 | 存储位置 | 能否进公开 Git | 说明 |
+| --- | --- | --- | --- |
+| 应用源码 | 仓库 | 可以 | 代码、测试、文档、迁移、模板。 |
+| 虚构 demo 数据 | seed 文件 | 可以 | 必须明显是虚构内容。 |
+| Inbox 原始输入 | PostgreSQL | 不可以 | 原文可能包含私人意图和业务信息。 |
+| 任务和项目状态 | PostgreSQL | 不可以 | 会暴露优先级、计划和未完成工作。 |
+| Agent 运行记录 | PostgreSQL | 不可以 | 可能暴露推理摘要和决策轨迹。 |
+| Wiki 笔记 | Markdown vault | 默认不可以 | 只发布脱敏后的示例笔记。 |
+| token 和凭据 | `.env` / secret store | 永远不可以 | 仓库只放 `.env.example` 占位值。 |
+| 服务器台账 | 私有 vault/docs | 永远不可以 | 内网 IP、端口、路径、业务映射都敏感。 |
+| 日志和截图 | 运行时文件 | 不可以 | 可能包含 URL、token、路径或私密文本。 |
+
+## 运行时数据
+
+Personal OS 把执行状态存在 PostgreSQL：
+
+- Inbox
+- Ideas
+- Tasks
+- Projects
+- Notes
+- Agent runs
+- 任务认领
+- 贡献记录
+- 复核记录
+- 活动事件
+- 通知 payload
+
+Personal Wiki 把长期知识存在 Markdown vault 和 JSON 索引：
+
+- Markdown 笔记
+- 标签和概念
+- 搜索索引
+- 图谱数据
+- 归档笔记
+
+公开仓库只应该包含软件引擎，不应该包含真实运行数据。
+
+## Token 边界
+
+读写 token 应该分开：
+
+- `PERSONAL_OS_API_TOKEN`：Personal OS 写接口。
+- `PERSONAL_OS_READ_TOKEN`：Personal OS 读接口。
+- `WIKI_API_TOKEN`：Wiki 写接口。
+- `WIKI_READ_TOKEN`：Wiki 读接口和浏览器 handoff。
+
+不要把写 token 回退成读 token 放进浏览器 cookie。不要把 token 放进 URL。不要把真实 token 粘到 issue、截图、示例或 Agent prompt 里。
+
+## 备份
+
+运行时备份要和源码分开：
+
+- Personal OS 用 PostgreSQL dump。
+- Personal Wiki 备份 Markdown vault。
+- `.env` 和部署密钥放密码管理器或 secret manager。
+
+真实备份不要进公开仓库。
+
+## 公开发布前检查
+
+从私有工作树发布或开 PR 前：
+
+1. 确认 `.env`、vault、日志、截图、dump、构建产物都被忽略。
+2. 跑 CI secret/private-data scan。
+3. 搜索内网网段、真实域名、用户名和部署路径。
+4. 人工复核 demo 数据。
+5. 如果历史提交曾包含私有产物，用干净历史发布。
+
+完整清单见 [`../OPEN_SOURCE_RELEASE.md`](../OPEN_SOURCE_RELEASE.md)。
+
+## 当前限制
+
+- 应用本身不负责加密运行时数据；需要依赖磁盘、数据库和主机安全。
+- 当前版本不是多租户 SaaS。
+- 内置鉴权是 token 模型；公开部署应放在有鉴权的反向代理后面。
+- Agent 自主执行受任务协议约束，但坏 Agent 仍可能提交坏产物，所以复核很重要。
+- 如果 token 泄露，删除 Git 历史不够，必须轮换 token。

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,192 @@
+# Getting Started
+
+This guide runs the public demo locally and shows the loop this project is
+built around:
+
+```text
+capture -> wiki memory -> task -> agent claim -> evidence -> review
+```
+
+The demo uses fake seed data only. Do not put real vaults, private server
+inventories, tokens, or task history into Git.
+
+## Prerequisites
+
+- Git
+- Docker and Docker Compose
+- Node.js 24 or newer
+- npm
+- Python 3.11 or newer
+
+## 1. Clone The Repository
+
+```bash
+git clone https://github.com/lawyer112/personal-os-wiki.git
+cd personal-os-wiki
+```
+
+## 2. Start Personal Wiki
+
+```bash
+cd personal-wiki
+cp .env.example .env
+docker compose up -d --build
+```
+
+Open:
+
+```text
+http://localhost:3422
+```
+
+The default `.env.example` enables read authentication and write
+authentication. Before exposing this service beyond your own machine, replace
+the placeholder tokens with long random values.
+
+## 3. Start Personal OS
+
+```bash
+cd ../personal-os-app
+cp .env.example .env
+docker compose up -d postgres
+npm ci
+npm run prisma:generate
+npm run prisma:migrate
+npm run prisma:seed
+npm run dev
+```
+
+Open:
+
+```text
+http://localhost:3000
+```
+
+For Wiki integration, set `WIKI_API_TOKEN` and `WIKI_READ_TOKEN` in
+`personal-os-app/.env` to match `personal-wiki/.env`.
+
+## 4. What You Should See
+
+After `npm run prisma:seed`, the app contains fictional demo data:
+
+| Surface | Demo item |
+| --- | --- |
+| Projects | `Acorn Launch Lab` |
+| Inbox | `Demo input: collect three customer notes...` |
+| Tasks | `Review the fictional launch checklist` |
+| Ideas | `Add a demo screenshot after UI polish` |
+| Notes | `Demo launch checklist` |
+| Activity | `demo.seeded` and task contribution events |
+
+Suggested click path:
+
+1. Open `Today` to see what the app treats as current work.
+2. Open `Tasks` and click `Review the fictional launch checklist`.
+3. Check the next action, definition of done, Wiki link, contribution, and
+   artifact.
+4. Open `Projects` and inspect `Acorn Launch Lab`.
+5. Open `Ideas` and confirm the screenshot idea stayed as an idea instead of
+   becoming a fake task.
+6. Open the Wiki service and ingest or browse Markdown notes separately.
+
+## 5. Minimal API Smoke Test
+
+Use the values from `personal-os-app/.env`.
+
+```bash
+curl -H "Authorization: Bearer <PERSONAL_OS_READ_TOKEN>" \
+  http://localhost:3000/api/today
+```
+
+Capture a small input:
+
+```bash
+curl -X POST http://localhost:3000/api/intake \
+  -H "Authorization: Bearer <PERSONAL_OS_API_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "manual",
+      "sourcePlatform": "demo",
+      "rawText": "Demo input: compare the agent queue with my current workflow.",
+      "createdBy": "user"
+    },
+    "agent": {
+      "model": "example-agent-model",
+      "reasoningSummary": "Classified demo input as one follow-up task."
+    },
+    "tasks": [
+      {
+        "title": "Compare the demo agent queue with my workflow",
+        "status": "todo",
+        "priority": "P2",
+        "agentTags": ["demo", "review"],
+        "nextAction": "Write one paragraph with the biggest gap.",
+        "definitionOfDone": "A review note is attached to the task."
+      }
+    ]
+  }'
+```
+
+Poll work for an agent:
+
+```bash
+curl -H "Authorization: Bearer <PERSONAL_OS_API_TOKEN>" \
+  "http://localhost:3000/api/agent-inbox?agentId=demo-agent&tags=demo,review"
+```
+
+Load context for a task:
+
+```bash
+curl -H "Authorization: Bearer <PERSONAL_OS_READ_TOKEN>" \
+  "http://localhost:3000/api/agent/context?taskId=<task-id>"
+```
+
+## 6. Endpoint Cheat Sheet
+
+| Purpose | Endpoint | Token |
+| --- | --- | --- |
+| Read today workspace | `GET /api/today` | read token in production |
+| Capture mixed input | `POST /api/intake` | `PERSONAL_OS_API_TOKEN` |
+| Agent polls work | `GET /api/agent-inbox` | `PERSONAL_OS_API_TOKEN` |
+| Agent loads context | `GET /api/agent/context?taskId=...` | `PERSONAL_OS_READ_TOKEN` |
+| Agent claims work | `POST /api/tasks/:id/claim` | `PERSONAL_OS_API_TOKEN` |
+| Agent heartbeats | `POST /api/tasks/:id/heartbeat` | `PERSONAL_OS_API_TOKEN` |
+| Agent submits work | `POST /api/tasks/:id/submit` | `PERSONAL_OS_API_TOKEN` |
+| Wiki ingest | `POST /api/ingest` | `WIKI_API_TOKEN` |
+
+The complete agent protocol is documented in
+[`AGENT_GUIDE.md`](./AGENT_GUIDE.md) and
+[`../personal-os-app/docs/HERMES_API.md`](../personal-os-app/docs/HERMES_API.md).
+
+## 7. First-Run Troubleshooting
+
+### Prisma client is missing
+
+Run:
+
+```bash
+npm run prisma:generate
+```
+
+### PostgreSQL connection fails
+
+Make sure the password in `personal-os-app/.env` matches the password used by
+the local compose service. The example config uses port `54329`.
+
+### Wiki opens but asks for auth
+
+That is expected when read auth is enabled. Use `WIKI_READ_TOKEN` from
+`personal-wiki/.env`, or open it through the Personal OS handoff route if you
+configured both services.
+
+### Do not see the demo project
+
+Run:
+
+```bash
+npm run prisma:seed
+```
+
+The seed command resets demo tables and recreates the fictional project,
+task, note, idea, contribution, artifact, and activity records.

--- a/docs/GETTING_STARTED.zh-CN.md
+++ b/docs/GETTING_STARTED.zh-CN.md
@@ -1,0 +1,182 @@
+# 快速上手
+
+这份文档用于在本地跑起公开 demo，并理解这个项目的核心闭环：
+
+```text
+输入碎片 -> Wiki 记忆 -> 任务 -> Agent 认领 -> 提交证据 -> 复核
+```
+
+demo 只使用虚构数据。不要把真实 vault、服务器台账、token、任务历史提交到 Git。
+
+## 前置要求
+
+- Git
+- Docker 和 Docker Compose
+- Node.js 24 或更新版本
+- npm
+- Python 3.11 或更新版本
+
+## 1. 克隆仓库
+
+```bash
+git clone https://github.com/lawyer112/personal-os-wiki.git
+cd personal-os-wiki
+```
+
+## 2. 启动 Personal Wiki
+
+```bash
+cd personal-wiki
+cp .env.example .env
+docker compose up -d --build
+```
+
+打开：
+
+```text
+http://localhost:3422
+```
+
+`.env.example` 默认开启读写鉴权。只要你准备把服务暴露到本机之外，就应该把里面的占位 token 换成长随机值。
+
+## 3. 启动 Personal OS
+
+```bash
+cd ../personal-os-app
+cp .env.example .env
+docker compose up -d postgres
+npm ci
+npm run prisma:generate
+npm run prisma:migrate
+npm run prisma:seed
+npm run dev
+```
+
+打开：
+
+```text
+http://localhost:3000
+```
+
+如果要联动 Wiki，把 `personal-os-app/.env` 里的 `WIKI_API_TOKEN` 和 `WIKI_READ_TOKEN` 改成与 `personal-wiki/.env` 一致。
+
+## 4. 你应该看到什么
+
+执行 `npm run prisma:seed` 后，系统会生成一组虚构 demo 数据：
+
+| 页面 | demo 内容 |
+| --- | --- |
+| Projects | `Acorn Launch Lab` |
+| Inbox | `Demo input: collect three customer notes...` |
+| Tasks | `Review the fictional launch checklist` |
+| Ideas | `Add a demo screenshot after UI polish` |
+| Notes | `Demo launch checklist` |
+| Activity | `demo.seeded` 和任务贡献记录 |
+
+建议点击路径：
+
+1. 打开 `Today`，看系统认为当前最该处理的工作。
+2. 打开 `Tasks`，点进 `Review the fictional launch checklist`。
+3. 查看下一步动作、完成定义、Wiki 链接、贡献记录和 artifact。
+4. 打开 `Projects`，查看 `Acorn Launch Lab`。
+5. 打开 `Ideas`，确认截图想法还停留在想法池，没有被强行变成任务。
+6. 打开 Wiki 服务，单独体验 Markdown 入库和浏览。
+
+## 5. 最小 API 测试
+
+使用 `personal-os-app/.env` 里的 token。
+
+```bash
+curl -H "Authorization: Bearer <PERSONAL_OS_READ_TOKEN>" \
+  http://localhost:3000/api/today
+```
+
+写入一条输入：
+
+```bash
+curl -X POST http://localhost:3000/api/intake \
+  -H "Authorization: Bearer <PERSONAL_OS_API_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": {
+      "sourceType": "manual",
+      "sourcePlatform": "demo",
+      "rawText": "Demo input: compare the agent queue with my current workflow.",
+      "createdBy": "user"
+    },
+    "agent": {
+      "model": "example-agent-model",
+      "reasoningSummary": "Classified demo input as one follow-up task."
+    },
+    "tasks": [
+      {
+        "title": "Compare the demo agent queue with my workflow",
+        "status": "todo",
+        "priority": "P2",
+        "agentTags": ["demo", "review"],
+        "nextAction": "Write one paragraph with the biggest gap.",
+        "definitionOfDone": "A review note is attached to the task."
+      }
+    ]
+  }'
+```
+
+让 Agent 拉取任务：
+
+```bash
+curl -H "Authorization: Bearer <PERSONAL_OS_API_TOKEN>" \
+  "http://localhost:3000/api/agent-inbox?agentId=demo-agent&tags=demo,review"
+```
+
+读取某个任务的上下文：
+
+```bash
+curl -H "Authorization: Bearer <PERSONAL_OS_READ_TOKEN>" \
+  "http://localhost:3000/api/agent/context?taskId=<task-id>"
+```
+
+## 6. API 速查
+
+| 目的 | Endpoint | Token |
+| --- | --- | --- |
+| 读取今日工作台 | `GET /api/today` | 生产环境需要 read token |
+| 写入混合输入 | `POST /api/intake` | `PERSONAL_OS_API_TOKEN` |
+| Agent 拉任务 | `GET /api/agent-inbox` | `PERSONAL_OS_API_TOKEN` |
+| Agent 读上下文 | `GET /api/agent/context?taskId=...` | `PERSONAL_OS_READ_TOKEN` |
+| Agent 认领任务 | `POST /api/tasks/:id/claim` | `PERSONAL_OS_API_TOKEN` |
+| Agent 心跳续约 | `POST /api/tasks/:id/heartbeat` | `PERSONAL_OS_API_TOKEN` |
+| Agent 提交产物 | `POST /api/tasks/:id/submit` | `PERSONAL_OS_API_TOKEN` |
+| Wiki 入库 | `POST /api/ingest` | `WIKI_API_TOKEN` |
+
+完整协议见：
+
+- [`AGENT_GUIDE.zh-CN.md`](./AGENT_GUIDE.zh-CN.md)
+- [`../personal-os-app/docs/HERMES_API.md`](../personal-os-app/docs/HERMES_API.md)
+
+## 7. 常见问题
+
+### Prisma client 缺失
+
+运行：
+
+```bash
+npm run prisma:generate
+```
+
+### PostgreSQL 连接失败
+
+确认 `personal-os-app/.env` 里的数据库密码和 compose 启动的本地数据库一致。示例配置使用端口 `54329`。
+
+### Wiki 打开后要求鉴权
+
+这是开启读鉴权后的正常行为。使用 `personal-wiki/.env` 里的 `WIKI_READ_TOKEN`，或者在两个服务都配置好之后通过 Personal OS 的 handoff 路由打开。
+
+### 没看到 demo 项目
+
+运行：
+
+```bash
+npm run prisma:seed
+```
+
+seed 命令会重置 demo 表，并重新创建虚构项目、任务、笔记、想法、贡献、artifact 和活动记录。

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,16 @@ README.
 
 ## Start Here
 
+- [Getting Started](./GETTING_STARTED.md)
+- [快速上手](./GETTING_STARTED.zh-CN.md)
 - [Architecture](./ARCHITECTURE.md)
 - [架构说明](./ARCHITECTURE.zh-CN.md)
 - [Agent guide](./AGENT_GUIDE.md)
 - [Agent 使用手册](./AGENT_GUIDE.zh-CN.md)
+- [API overview](./API_OVERVIEW.md)
+- [Data safety](./DATA_SAFETY.md)
+- [数据安全](./DATA_SAFETY.zh-CN.md)
+- [Roadmap](./ROADMAP.md)
 - [Repository strategy](./REPOSITORY_STRATEGY.md)
 - [仓库拆分与开源策略](./REPOSITORY_STRATEGY.zh-CN.md)
 
@@ -24,12 +30,16 @@ README.
 ## Release Docs
 
 - [Open source release process](../OPEN_SOURCE_RELEASE.md)
+- [Security policy](../SECURITY.md)
+- [Repository permissions](./PERMISSIONS.md)
 
 ## Reading Order For Reviewers
 
 1. Read the root [`README.md`](../README.md) or [`README.zh-CN.md`](../README.zh-CN.md).
-2. Read the architecture document in your preferred language.
-3. Read the Agent guide if you are reviewing task execution or autonomous
+2. Run or skim the Getting Started guide.
+3. Read the architecture document in your preferred language.
+4. Read the Agent guide if you are reviewing task execution or autonomous
    workers.
-4. Read `OPEN_SOURCE_RELEASE.md` before publishing or making the repository
+5. Read `DATA_SAFETY.md` before connecting real notes, tasks, or server data.
+6. Read `OPEN_SOURCE_RELEASE.md` before publishing or making the repository
    public.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,46 @@
+# Roadmap
+
+This project is an early public engine, not a polished hosted product. The
+roadmap is organized around making the agent work loop more understandable,
+safer, and easier to adopt.
+
+## Now
+
+- Clearer GitHub landing docs.
+- Fake demo dataset for first-run onboarding.
+- CI for tests, audit, typecheck, lint, app build, Docker builds, Wiki compile,
+  and secret/private-data scan.
+- Token boundaries for Personal OS and Personal Wiki.
+- Agent task protocol: poll, claim, heartbeat, contribute, submit, review.
+
+## Next
+
+- Public screenshots using fake seed data only.
+- A browser walkthrough for Today, Inbox, Tasks, Projects, Ideas, Wiki, and
+  Agent Context.
+- More copyable API examples and smoke scripts.
+- Better first-run checks for token mismatch between Personal OS and Personal
+  Wiki.
+- More tests around failure paths in task claims, stale leases, review decisions,
+  and Wiki ingest errors.
+
+## Later
+
+- Agent self-assignment by capability tags.
+- Richer project dashboards and revenue/work-priority views.
+- Knowledge graph insights and knowledge-gap detection.
+- Safer import/export for existing Markdown vaults.
+- Optional notification adapters beyond Telegram-style payloads.
+- Optional OpenAPI/Bruno/Postman artifacts for API consumers.
+
+## Not Goals For The Current Release
+
+- Hosted SaaS.
+- Multi-tenant organization management.
+- OAuth/user-account system.
+- Fully autonomous agents that can bypass review.
+- Publishing real private vaults or server inventories.
+- Replacing Obsidian, Logseq, Notion, or your editor.
+
+The goal is narrower: make personal knowledge actionable and make agent work
+claimable, reviewable, and resumable.

--- a/docs/assets/screenshots/README.md
+++ b/docs/assets/screenshots/README.md
@@ -1,0 +1,14 @@
+# Screenshots
+
+Public screenshots should use fake seed data only.
+
+Planned captures:
+
+- `today-workspace.png`
+- `task-review-flow.png`
+- `project-timeline.png`
+- `agent-context-panel.png`
+- `wiki-note-graph.png`
+
+Do not capture real inbox items, real task history, real vault notes, private
+network addresses, tokens, browser history, or deployment paths.


### PR DESCRIPTION
## Summary
- rebuild the English and Chinese landing README into a fuller GitHub homepage with badges, positioning, use cases, demo path, screenshots plan, architecture, agent protocol, data safety, limitations, and roadmap
- add first-run onboarding docs in English and Chinese
- add API overview, data safety docs, roadmap, and screenshot capture guidance
- update the docs index so new visitors have a clear reading order

## Review input integrated
- product appeal: stronger hero, category, use-case table, normal wiki comparison
- onboarding: 10-minute demo path, expected seed data, minimal API smoke, endpoint cheat sheet
- open-source trust: CI/license badges, data safety model, limitations, roadmap, screenshot policy

## Verification
- git diff --check
- UTF-8 check for README/docs: no replacement characters, no NUL bytes
- relative Markdown link check: 0 missing links
- ripgrep scan for common private key/token patterns

## Notes
Docs-only change. No runtime code changed.
