### PR TITLE
Add README visual assets and jump links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # Personal OS + Personal Wiki
 
+<p align="center">
+  <img src="./docs/assets/readme/hero.svg" alt="Personal OS + Personal Wiki hero: Stop collecting. Start closing loops." width="100%">
+</p>
+
 [![CI](https://github.com/lawyer112/personal-os-wiki/actions/workflows/ci.yml/badge.svg)](https://github.com/lawyer112/personal-os-wiki/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Local First](https://img.shields.io/badge/local--first-yes-2ea44f)](#data-safety)
 [![Agent Ready](https://img.shields.io/badge/agent--ready-task%20claiming-blue)](#agent-protocol)
+[![Markdown Wiki](https://img.shields.io/badge/markdown-wiki-7c3aed)](#personal-wiki)
+[![Task Protocol](https://img.shields.io/badge/task-protocol-f97316)](#agent-protocol)
+
+<p align="center">
+  <a href="#10-minute-demo-path"><img src="https://img.shields.io/badge/Run%20the%20demo-10%20minutes-0f766e?style=for-the-badge" alt="Run the demo"></a>
+  <a href="./docs/GETTING_STARTED.md"><img src="https://img.shields.io/badge/Getting%20Started-guide-1d4ed8?style=for-the-badge" alt="Getting Started"></a>
+  <a href="./docs/AGENT_GUIDE.md"><img src="https://img.shields.io/badge/Agent%20Guide-protocol-7c3aed?style=for-the-badge" alt="Agent Guide"></a>
+  <a href="./docs/API_OVERVIEW.md"><img src="https://img.shields.io/badge/API-overview-f97316?style=for-the-badge" alt="API Overview"></a>
+  <a href="./docs/DATA_SAFETY.md"><img src="https://img.shields.io/badge/Data%20Safety-local--first-334155?style=for-the-badge" alt="Data Safety"></a>
+</p>
 
 [中文说明](./README.zh-CN.md)
 
@@ -29,6 +43,10 @@ messy input -> durable wiki memory -> executable tasks
   -> agent claim -> evidence submission -> human/reviewer approval
   -> knowledge base updated for the next run
 ```
+
+<p align="center">
+  <img src="./docs/assets/readme/loop.svg" alt="Capture, Wiki, Task, Agent, Review loop" width="100%">
+</p>
 
 ## What This Project Is
 
@@ -169,6 +187,10 @@ Planned captures:
 - Wiki note graph
 
 ## Architecture
+
+<p align="center">
+  <img src="./docs/assets/readme/architecture.svg" alt="Personal OS owns work state. Personal Wiki owns durable knowledge. Agent Guide connects them." width="100%">
+</p>
 
 ```text
 Human input

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,9 +1,23 @@
 # Personal OS + Personal Wiki
 
+<p align="center">
+  <img src="./docs/assets/readme/hero.svg" alt="Personal OS + Personal Wiki hero: Stop collecting. Start closing loops." width="100%">
+</p>
+
 [![CI](https://github.com/lawyer112/personal-os-wiki/actions/workflows/ci.yml/badge.svg)](https://github.com/lawyer112/personal-os-wiki/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Local First](https://img.shields.io/badge/local--first-yes-2ea44f)](#数据安全)
 [![Agent Ready](https://img.shields.io/badge/agent--ready-task%20claiming-blue)](#agent-协议)
+[![Markdown Wiki](https://img.shields.io/badge/markdown-wiki-7c3aed)](#personal-wiki)
+[![Task Protocol](https://img.shields.io/badge/task-protocol-f97316)](#agent-协议)
+
+<p align="center">
+  <a href="#10-分钟-demo"><img src="https://img.shields.io/badge/运行%20Demo-10%20分钟-0f766e?style=for-the-badge" alt="运行 Demo"></a>
+  <a href="./docs/GETTING_STARTED.zh-CN.md"><img src="https://img.shields.io/badge/快速上手-guide-1d4ed8?style=for-the-badge" alt="快速上手"></a>
+  <a href="./docs/AGENT_GUIDE.zh-CN.md"><img src="https://img.shields.io/badge/Agent%20手册-protocol-7c3aed?style=for-the-badge" alt="Agent 手册"></a>
+  <a href="./docs/API_OVERVIEW.md"><img src="https://img.shields.io/badge/API-总览-f97316?style=for-the-badge" alt="API 总览"></a>
+  <a href="./docs/DATA_SAFETY.zh-CN.md"><img src="https://img.shields.io/badge/数据安全-local--first-334155?style=for-the-badge" alt="数据安全"></a>
+</p>
 
 [English README](./README.md)
 
@@ -24,6 +38,10 @@ Personal OS + Personal Wiki 把收藏夹、语音转写、碎碎念、项目进�
   -> Agent 认领 -> 提交证据 -> 人或 Reviewer 复核
   -> 结果回写知识库，供下一轮继续使用
 ```
+
+<p align="center">
+  <img src="./docs/assets/readme/loop.svg" alt="输入、Wiki、任务、Agent、复核闭环" width="100%">
+</p>
 
 ## 这是什么
 
@@ -143,6 +161,10 @@ seed 后你会看到一组虚构数据：
 - [Getting Started](./docs/GETTING_STARTED.md)
 
 ## 架构图
+
+<p align="center">
+  <img src="./docs/assets/readme/architecture.svg" alt="Personal OS 管工作状态，Personal Wiki 管长期知识，Agent Guide 连接二者。" width="100%">
+</p>
 
 ```text
 用户输入

--- a/docs/assets/readme/architecture.svg
+++ b/docs/assets/readme/architecture.svg
@@ -1,0 +1,42 @@
+<svg width="1280" height="420" viewBox="0 0 1280 420" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Personal OS and Personal Wiki architecture</title>
+  <desc id="desc">Personal OS owns work state, Personal Wiki owns durable knowledge, and agents connect the two through a protocol.</desc>
+  <rect width="1280" height="420" rx="32" fill="#0B1020"/>
+  <defs>
+    <linearGradient id="os" x1="120" y1="90" x2="486" y2="330" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1D4ED8"/>
+      <stop offset="1" stop-color="#0F766E"/>
+    </linearGradient>
+    <linearGradient id="wiki" x1="794" y1="90" x2="1160" y2="330" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#EA580C"/>
+    </linearGradient>
+  </defs>
+  <text x="640" y="58" fill="#F8FAFC" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="30" font-weight="800" text-anchor="middle">Simple boundary, useful protocol</text>
+  <text x="640" y="88" fill="#94A3B8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17" text-anchor="middle">Work state lives in Personal OS. Durable memory lives in Personal Wiki. Agents bridge them.</text>
+
+  <g font-family="Inter, Segoe UI, Arial, sans-serif">
+    <rect x="100" y="122" width="360" height="206" rx="28" fill="url(#os)" fill-opacity="0.9"/>
+    <text x="280" y="170" fill="#FFFFFF" font-size="28" font-weight="800" text-anchor="middle">Personal OS</text>
+    <text x="280" y="205" fill="#DBEAFE" font-size="17" text-anchor="middle">Inbox • Today • Projects • Tasks</text>
+    <text x="280" y="233" fill="#DBEAFE" font-size="17" text-anchor="middle">Agent runs • Claims • Reviews</text>
+    <text x="280" y="273" fill="#FFFFFF" font-size="20" font-weight="700" text-anchor="middle">source of truth for work</text>
+
+    <rect x="820" y="122" width="360" height="206" rx="28" fill="url(#wiki)" fill-opacity="0.9"/>
+    <text x="1000" y="170" fill="#FFFFFF" font-size="28" font-weight="800" text-anchor="middle">Personal Wiki</text>
+    <text x="1000" y="205" fill="#F5E8FF" font-size="17" text-anchor="middle">Markdown • Tags • Concepts</text>
+    <text x="1000" y="233" fill="#F5E8FF" font-size="17" text-anchor="middle">Backlinks • Search • Graph</text>
+    <text x="1000" y="273" fill="#FFFFFF" font-size="20" font-weight="700" text-anchor="middle">source of truth for memory</text>
+
+    <rect x="515" y="142" width="250" height="166" rx="30" fill="#FFFFFF" fill-opacity="0.08" stroke="#FFFFFF" stroke-opacity="0.18"/>
+    <text x="640" y="185" fill="#FFFFFF" font-size="25" font-weight="800" text-anchor="middle">Agent Guide</text>
+    <text x="640" y="218" fill="#CBD5E1" font-size="16" text-anchor="middle">poll → claim → context</text>
+    <text x="640" y="244" fill="#CBD5E1" font-size="16" text-anchor="middle">heartbeat → submit → review</text>
+    <text x="640" y="278" fill="#73FBD3" font-size="18" font-weight="700" text-anchor="middle">portable operating rules</text>
+
+    <path d="M470 224H506" stroke="#73FBD3" stroke-width="5" stroke-linecap="round"/>
+    <path d="M493 210L510 224L493 238" stroke="#73FBD3" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M776 224H812" stroke="#FFB86B" stroke-width="5" stroke-linecap="round"/>
+    <path d="M799 210L816 224L799 238" stroke="#FFB86B" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/docs/assets/readme/hero.svg
+++ b/docs/assets/readme/hero.svg
@@ -1,0 +1,62 @@
+<svg width="1280" height="520" viewBox="0 0 1280 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Personal OS + Personal Wiki hero</title>
+  <desc id="desc">A local-first workbench that turns messy input into wiki memory, claimable tasks, and reviewable agent output.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1280" y2="520" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#09111F"/>
+      <stop offset="0.45" stop-color="#0F2A2D"/>
+      <stop offset="1" stop-color="#321A14"/>
+    </linearGradient>
+    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(248 128) rotate(38) scale(320 220)">
+      <stop stop-color="#73FBD3" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="#73FBD3" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1044 390) rotate(22) scale(360 260)">
+      <stop stop-color="#FFB86B" stop-opacity="0.46"/>
+      <stop offset="1" stop-color="#FFB86B" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="card" x1="170" y1="156" x2="1110" y2="424" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF" stop-opacity="0.12"/>
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.06"/>
+    </linearGradient>
+    <filter id="shadow" x="120" y="112" width="1040" height="368" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="24" stdDeviation="34" flood-color="#000000" flood-opacity="0.32"/>
+    </filter>
+  </defs>
+
+  <rect width="1280" height="520" rx="36" fill="url(#bg)"/>
+  <rect width="1280" height="520" rx="36" fill="url(#glowA)"/>
+  <rect width="1280" height="520" rx="36" fill="url(#glowB)"/>
+
+  <path d="M70 80C170 118 210 37 304 78C398 119 448 55 540 90C632 125 680 73 764 105C848 137 904 82 1000 119C1096 156 1160 108 1210 144" stroke="#FFFFFF" stroke-opacity="0.11" stroke-width="2"/>
+  <path d="M58 430C160 380 206 472 314 420C422 368 486 448 590 398C694 348 764 430 872 376C980 322 1070 398 1220 338" stroke="#FFFFFF" stroke-opacity="0.11" stroke-width="2"/>
+
+  <g filter="url(#shadow)">
+    <rect x="150" y="126" width="980" height="268" rx="30" fill="url(#card)" stroke="#FFFFFF" stroke-opacity="0.18"/>
+    <rect x="178" y="154" width="216" height="48" rx="24" fill="#73FBD3" fill-opacity="0.16" stroke="#73FBD3" stroke-opacity="0.42"/>
+    <text x="286" y="184" fill="#A8FFE8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="19" font-weight="700" text-anchor="middle">LOCAL-FIRST AGENT WORKBENCH</text>
+
+    <text x="190" y="252" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="55" font-weight="800" letter-spacing="-1.4">
+      Stop collecting.
+    </text>
+    <text x="190" y="314" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="55" font-weight="800" letter-spacing="-1.4">
+      Start closing loops.
+    </text>
+    <text x="194" y="354" fill="#CBE7DF" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="22">
+      Links, voice notes, rough ideas, and agent outputs become wiki memory,
+    </text>
+    <text x="194" y="382" fill="#CBE7DF" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="22">
+      claimable tasks, submitted evidence, and reviewable work.
+    </text>
+
+    <g transform="translate(795 174)">
+      <rect width="270" height="178" rx="24" fill="#07131C" fill-opacity="0.7" stroke="#FFFFFF" stroke-opacity="0.14"/>
+      <circle cx="38" cy="40" r="10" fill="#73FBD3"/>
+      <text x="60" y="47" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">Inbox captures source</text>
+      <circle cx="38" cy="88" r="10" fill="#B9A8FF"/>
+      <text x="60" y="95" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">Wiki keeps memory</text>
+      <circle cx="38" cy="136" r="10" fill="#FFB86B"/>
+      <text x="60" y="143" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">Agents claim tasks</text>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/readme/loop.svg
+++ b/docs/assets/readme/loop.svg
@@ -1,0 +1,61 @@
+<svg width="1280" height="360" viewBox="0 0 1280 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Personal OS + Personal Wiki execution loop</title>
+  <desc id="desc">A visual loop from capture to wiki memory, task creation, agent claim, evidence submission, review, and knowledge update.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1280" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8FAFC"/>
+      <stop offset="1" stop-color="#FFF7ED"/>
+    </linearGradient>
+    <filter id="shadow" x="-20" y="-20" width="220" height="170" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#0F172A" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="1280" height="360" rx="32" fill="url(#bg)"/>
+  <text x="640" y="58" fill="#0F172A" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="30" font-weight="800" text-anchor="middle">The loop this project adds</text>
+  <text x="640" y="91" fill="#475569" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" text-anchor="middle">From saved fragments to reviewable work, without relying on stale chat history.</text>
+
+  <g font-family="Inter, Segoe UI, Arial, sans-serif">
+    <g transform="translate(58 138)" filter="url(#shadow)">
+      <rect width="160" height="116" rx="24" fill="#FFFFFF" stroke="#E2E8F0"/>
+      <text x="80" y="45" fill="#0F766E" font-size="18" font-weight="800" text-anchor="middle">1. Capture</text>
+      <text x="80" y="76" fill="#475569" font-size="15" text-anchor="middle">links, voice,</text>
+      <text x="80" y="96" fill="#475569" font-size="15" text-anchor="middle">rough thoughts</text>
+    </g>
+    <path d="M232 196H316" stroke="#94A3B8" stroke-width="4" stroke-linecap="round"/>
+    <path d="M304 184L320 196L304 208" stroke="#94A3B8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <g transform="translate(336 138)" filter="url(#shadow)">
+      <rect width="160" height="116" rx="24" fill="#FFFFFF" stroke="#E2E8F0"/>
+      <text x="80" y="45" fill="#6D28D9" font-size="18" font-weight="800" text-anchor="middle">2. Wiki</text>
+      <text x="80" y="76" fill="#475569" font-size="15" text-anchor="middle">durable notes,</text>
+      <text x="80" y="96" fill="#475569" font-size="15" text-anchor="middle">tags, graph</text>
+    </g>
+    <path d="M510 196H594" stroke="#94A3B8" stroke-width="4" stroke-linecap="round"/>
+    <path d="M582 184L598 196L582 208" stroke="#94A3B8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <g transform="translate(614 138)" filter="url(#shadow)">
+      <rect width="160" height="116" rx="24" fill="#FFFFFF" stroke="#E2E8F0"/>
+      <text x="80" y="45" fill="#B45309" font-size="18" font-weight="800" text-anchor="middle">3. Task</text>
+      <text x="80" y="76" fill="#475569" font-size="15" text-anchor="middle">next action,</text>
+      <text x="80" y="96" fill="#475569" font-size="15" text-anchor="middle">definition of done</text>
+    </g>
+    <path d="M788 196H872" stroke="#94A3B8" stroke-width="4" stroke-linecap="round"/>
+    <path d="M860 184L876 196L860 208" stroke="#94A3B8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <g transform="translate(892 138)" filter="url(#shadow)">
+      <rect width="160" height="116" rx="24" fill="#FFFFFF" stroke="#E2E8F0"/>
+      <text x="80" y="45" fill="#1D4ED8" font-size="18" font-weight="800" text-anchor="middle">4. Agent</text>
+      <text x="80" y="76" fill="#475569" font-size="15" text-anchor="middle">claim, heartbeat,</text>
+      <text x="80" y="96" fill="#475569" font-size="15" text-anchor="middle">submit evidence</text>
+    </g>
+    <path d="M1066 196H1150" stroke="#94A3B8" stroke-width="4" stroke-linecap="round"/>
+    <path d="M1138 184L1154 196L1138 208" stroke="#94A3B8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <g transform="translate(1168 138)" filter="url(#shadow)">
+      <rect width="54" height="116" rx="24" fill="#0F172A"/>
+      <text x="27" y="42" fill="#FFFFFF" font-size="14" font-weight="800" text-anchor="middle">5</text>
+      <text x="27" y="68" fill="#FFFFFF" font-size="12" font-weight="700" text-anchor="middle">Review</text>
+      <text x="27" y="88" fill="#CBD5E1" font-size="11" text-anchor="middle">update</text>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/screenshots/README.md
+++ b/docs/assets/screenshots/README.md
@@ -2,6 +2,9 @@
 
 Public screenshots should use fake seed data only.
 
+The decorative README diagrams live in `../readme/` and are safe to commit
+because they contain no runtime data.
+
 Planned captures:
 
 - `today-workspace.png`


### PR DESCRIPTION
## Summary
- add local SVG README visuals: hero, execution loop, and architecture diagram
- add clickable jump-link badges for demo, getting started, agent guide, API, and data safety
- wire the visual assets into both English and Chinese README pages
- document that decorative README diagrams are separate from real-data screenshots

## Verification
- SVG XML parse check
- relative Markdown/HTML link check: 0 missing links
- UTF-8 check: no replacement characters, no NUL bytes
- git diff --check
- ripgrep scan for common private key/token patterns

## Notes
Docs/assets-only change. No runtime code changed.
