### PR TITLE
Refine README hero and Chinese entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 <p align="center">
   <a href="#10-minute-demo-path"><img src="https://img.shields.io/badge/Run%20the%20demo-10%20minutes-0f766e?style=for-the-badge" alt="Run the demo"></a>
+  <a href="./README.zh-CN.md"><img src="https://img.shields.io/badge/中文说明-完整中文版-dc2626?style=for-the-badge" alt="中文说明"></a>
   <a href="./docs/GETTING_STARTED.md"><img src="https://img.shields.io/badge/Getting%20Started-guide-1d4ed8?style=for-the-badge" alt="Getting Started"></a>
   <a href="./docs/AGENT_GUIDE.md"><img src="https://img.shields.io/badge/Agent%20Guide-protocol-7c3aed?style=for-the-badge" alt="Agent Guide"></a>
   <a href="./docs/API_OVERVIEW.md"><img src="https://img.shields.io/badge/API-overview-f97316?style=for-the-badge" alt="API Overview"></a>
@@ -23,6 +24,23 @@
 
 **Category:** local-first agent workbench, Markdown knowledge base, task
 execution protocol.
+
+<details>
+<summary><strong>中文速览：这不是第二大脑，是推进引擎</strong></summary>
+
+Personal OS + Personal Wiki 把收藏夹、语音转写、碎碎念、项目进展和 Agent 产物，变成有人认领、有人提交证据、有人复核的任务。
+
+它的核心闭环是：
+
+```text
+碎片输入 -> Wiki 长期记忆 -> 可执行任务
+  -> Agent 认领 -> 提交证据 -> 人或 Reviewer 复核
+  -> 结果回写知识库，供下一轮继续使用
+```
+
+完整中文说明见 [README.zh-CN.md](./README.zh-CN.md)。
+
+</details>
 
 **Not a second brain. A follow-through engine for humans and agents.**
 

--- a/docs/assets/readme/hero.svg
+++ b/docs/assets/readme/hero.svg
@@ -1,62 +1,98 @@
-<svg width="1280" height="520" viewBox="0 0 1280 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">Personal OS + Personal Wiki hero</title>
-  <desc id="desc">A local-first workbench that turns messy input into wiki memory, claimable tasks, and reviewable agent output.</desc>
+<svg width="1280" height="640" viewBox="0 0 1280 640" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Personal OS + Personal Wiki product preview</title>
+  <desc id="desc">A product-style preview showing Inbox, Today, Tasks, Wiki memory, and an Agent Queue working together.</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1280" y2="520" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#09111F"/>
-      <stop offset="0.45" stop-color="#0F2A2D"/>
-      <stop offset="1" stop-color="#321A14"/>
+    <linearGradient id="page" x1="0" y1="0" x2="1280" y2="640" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFDF8"/>
+      <stop offset="0.45" stop-color="#F4F8F6"/>
+      <stop offset="1" stop-color="#EEF4FF"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(248 128) rotate(38) scale(320 220)">
-      <stop stop-color="#73FBD3" stop-opacity="0.42"/>
-      <stop offset="1" stop-color="#73FBD3" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1044 390) rotate(22) scale(360 260)">
-      <stop stop-color="#FFB86B" stop-opacity="0.46"/>
-      <stop offset="1" stop-color="#FFB86B" stop-opacity="0"/>
-    </radialGradient>
-    <linearGradient id="card" x1="170" y1="156" x2="1110" y2="424" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#FFFFFF" stop-opacity="0.12"/>
-      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.06"/>
+    <linearGradient id="ink" x1="118" y1="132" x2="550" y2="506" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#102A43"/>
+      <stop offset="1" stop-color="#173B35"/>
     </linearGradient>
-    <filter id="shadow" x="120" y="112" width="1040" height="368" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feDropShadow dx="0" dy="24" stdDeviation="34" flood-color="#000000" flood-opacity="0.32"/>
+    <linearGradient id="screen" x1="604" y1="98" x2="1158" y2="538" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#F8FAFC"/>
+    </linearGradient>
+    <filter id="softShadow" x="520" y="54" width="706" height="548" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="28" stdDeviation="32" flood-color="#0F172A" flood-opacity="0.16"/>
+    </filter>
+    <filter id="cardShadow" x="-20" y="-20" width="260" height="160" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#0F172A" flood-opacity="0.08"/>
     </filter>
   </defs>
 
-  <rect width="1280" height="520" rx="36" fill="url(#bg)"/>
-  <rect width="1280" height="520" rx="36" fill="url(#glowA)"/>
-  <rect width="1280" height="520" rx="36" fill="url(#glowB)"/>
+  <rect width="1280" height="640" rx="34" fill="url(#page)"/>
+  <circle cx="118" cy="96" r="160" fill="#99F6E4" fill-opacity="0.25"/>
+  <circle cx="1116" cy="536" r="190" fill="#BFDBFE" fill-opacity="0.42"/>
+  <circle cx="936" cy="118" r="120" fill="#FED7AA" fill-opacity="0.34"/>
 
-  <path d="M70 80C170 118 210 37 304 78C398 119 448 55 540 90C632 125 680 73 764 105C848 137 904 82 1000 119C1096 156 1160 108 1210 144" stroke="#FFFFFF" stroke-opacity="0.11" stroke-width="2"/>
-  <path d="M58 430C160 380 206 472 314 420C422 368 486 448 590 398C694 348 764 430 872 376C980 322 1070 398 1220 338" stroke="#FFFFFF" stroke-opacity="0.11" stroke-width="2"/>
+  <g font-family="Inter, Segoe UI, Arial, sans-serif">
+    <text x="92" y="126" fill="#0F766E" font-size="18" font-weight="800" letter-spacing="1.6">LOCAL-FIRST AGENT WORKBENCH</text>
+    <text x="92" y="190" fill="url(#ink)" font-size="58" font-weight="850" letter-spacing="-1.6">Personal OS</text>
+    <text x="92" y="252" fill="url(#ink)" font-size="58" font-weight="850" letter-spacing="-1.6">+ Personal Wiki</text>
+    <text x="96" y="306" fill="#475569" font-size="23">Turn messy input into memory, claimable tasks,</text>
+    <text x="96" y="337" fill="#475569" font-size="23">submitted evidence, and reviewable agent work.</text>
 
-  <g filter="url(#shadow)">
-    <rect x="150" y="126" width="980" height="268" rx="30" fill="url(#card)" stroke="#FFFFFF" stroke-opacity="0.18"/>
-    <rect x="178" y="154" width="216" height="48" rx="24" fill="#73FBD3" fill-opacity="0.16" stroke="#73FBD3" stroke-opacity="0.42"/>
-    <text x="286" y="184" fill="#A8FFE8" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="19" font-weight="700" text-anchor="middle">LOCAL-FIRST AGENT WORKBENCH</text>
+    <g transform="translate(94 382)">
+      <rect width="138" height="42" rx="21" fill="#0F766E"/>
+      <text x="69" y="28" fill="#FFFFFF" font-size="16" font-weight="800" text-anchor="middle">Inbox</text>
+      <rect x="154" width="132" height="42" rx="21" fill="#1D4ED8"/>
+      <text x="220" y="28" fill="#FFFFFF" font-size="16" font-weight="800" text-anchor="middle">Tasks</text>
+      <rect x="302" width="126" height="42" rx="21" fill="#7C3AED"/>
+      <text x="365" y="28" fill="#FFFFFF" font-size="16" font-weight="800" text-anchor="middle">Wiki</text>
+      <rect x="444" width="146" height="42" rx="21" fill="#EA580C"/>
+      <text x="517" y="28" fill="#FFFFFF" font-size="16" font-weight="800" text-anchor="middle">Review</text>
+    </g>
 
-    <text x="190" y="252" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="55" font-weight="800" letter-spacing="-1.4">
-      Stop collecting.
-    </text>
-    <text x="190" y="314" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="55" font-weight="800" letter-spacing="-1.4">
-      Start closing loops.
-    </text>
-    <text x="194" y="354" fill="#CBE7DF" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="22">
-      Links, voice notes, rough ideas, and agent outputs become wiki memory,
-    </text>
-    <text x="194" y="382" fill="#CBE7DF" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="22">
-      claimable tasks, submitted evidence, and reviewable work.
-    </text>
+    <path d="M98 486C176 454 224 516 306 482C388 448 438 510 522 470" stroke="#0F766E" stroke-width="4" stroke-linecap="round" stroke-opacity="0.25"/>
+  </g>
 
-    <g transform="translate(795 174)">
-      <rect width="270" height="178" rx="24" fill="#07131C" fill-opacity="0.7" stroke="#FFFFFF" stroke-opacity="0.14"/>
-      <circle cx="38" cy="40" r="10" fill="#73FBD3"/>
-      <text x="60" y="47" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">Inbox captures source</text>
-      <circle cx="38" cy="88" r="10" fill="#B9A8FF"/>
-      <text x="60" y="95" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">Wiki keeps memory</text>
-      <circle cx="38" cy="136" r="10" fill="#FFB86B"/>
-      <text x="60" y="143" fill="#F7FFF9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">Agents claim tasks</text>
+  <g filter="url(#softShadow)">
+    <rect x="586" y="88" width="590" height="464" rx="30" fill="url(#screen)" stroke="#D7DEE8"/>
+    <rect x="586" y="88" width="590" height="58" rx="30" fill="#0F172A"/>
+    <circle cx="626" cy="117" r="7" fill="#FB7185"/>
+    <circle cx="651" cy="117" r="7" fill="#FBBF24"/>
+    <circle cx="676" cy="117" r="7" fill="#34D399"/>
+    <text x="718" y="124" fill="#CBD5E1" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700">localhost:3000 / Today</text>
+
+    <g font-family="Inter, Segoe UI, Arial, sans-serif">
+      <rect x="618" y="174" width="148" height="338" rx="22" fill="#F1F5F9"/>
+      <text x="642" y="212" fill="#0F172A" font-size="18" font-weight="850">Personal OS</text>
+      <text x="642" y="254" fill="#0F766E" font-size="15" font-weight="800">Today</text>
+      <text x="642" y="288" fill="#475569" font-size="15">Inbox</text>
+      <text x="642" y="322" fill="#475569" font-size="15">Projects</text>
+      <text x="642" y="356" fill="#475569" font-size="15">Tasks</text>
+      <text x="642" y="390" fill="#475569" font-size="15">Reviews</text>
+      <text x="642" y="424" fill="#475569" font-size="15">Wiki</text>
+
+      <text x="798" y="205" fill="#0F172A" font-size="24" font-weight="850">Today workspace</text>
+      <text x="798" y="232" fill="#64748B" font-size="15">What should move next?</text>
+
+      <g transform="translate(798 258)" filter="url(#cardShadow)">
+        <rect width="326" height="86" rx="20" fill="#FFFFFF" stroke="#E2E8F0"/>
+        <rect x="18" y="18" width="54" height="24" rx="12" fill="#DCFCE7"/>
+        <text x="45" y="35" fill="#166534" font-size="12" font-weight="800" text-anchor="middle">P1</text>
+        <text x="88" y="36" fill="#0F172A" font-size="17" font-weight="800">Review launch checklist</text>
+        <text x="88" y="62" fill="#64748B" font-size="14">definition of done + artifact required</text>
+      </g>
+
+      <g transform="translate(798 364)" filter="url(#cardShadow)">
+        <rect width="154" height="118" rx="20" fill="#FFFFFF" stroke="#E2E8F0"/>
+        <text x="22" y="34" fill="#7C3AED" font-size="15" font-weight="850">Wiki memory</text>
+        <text x="22" y="64" fill="#475569" font-size="13">Demo launch</text>
+        <text x="22" y="84" fill="#475569" font-size="13">checklist.md</text>
+        <path d="M28 96H126" stroke="#DDD6FE" stroke-width="4" stroke-linecap="round"/>
+      </g>
+
+      <g transform="translate(970 364)" filter="url(#cardShadow)">
+        <rect width="154" height="118" rx="20" fill="#FFFFFF" stroke="#E2E8F0"/>
+        <text x="22" y="34" fill="#EA580C" font-size="15" font-weight="850">Agent queue</text>
+        <text x="22" y="64" fill="#475569" font-size="13">claim lease</text>
+        <text x="22" y="84" fill="#475569" font-size="13">heartbeat</text>
+        <path d="M28 96H126" stroke="#FED7AA" stroke-width="4" stroke-linecap="round"/>
+      </g>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the README hero with a product-style SVG mockup instead of the previous poster-like banner
- add a prominent Chinese README jump button near the top of the homepage
- add an inline Chinese quick overview in README.md so Chinese readers can understand the project without leaving the homepage

## Answer to the language-navigation question
GitHub renders README.md as the repository homepage by default. README.zh-CN.md is a separate page, but it can be linked directly from the homepage. This PR keeps the full Chinese README as a separate page and adds an inline Chinese overview on the homepage.

## Verification
- SVG XML parse check
- relative Markdown/HTML link check: 0 missing links
- UTF-8 check: no replacement characters, no NUL bytes
- git diff --check
- ripgrep scan for common private key/token patterns

## Notes
Docs/assets-only change. No runtime code changed.
