### PR TITLE
chore(deps): add personal-wiki pip dependabot and npm groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,32 @@ updates:
     labels:
       - dependencies
       - personal-os-app
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+
+  - package-ecosystem: pip
+    directory: /personal-wiki
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - personal-wiki
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
 
   - package-ecosystem: github-actions
     directory: /
@@ -17,3 +43,6 @@ updates:
     labels:
       - dependencies
       - github-actions
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope

--- a/personal-wiki/requirements.txt
+++ b/personal-wiki/requirements.txt
@@ -1,0 +1,5 @@
+# personal-wiki requirements
+# This file is intentionally minimal: personal-wiki/api/server.py uses only the
+# Python standard library. PyYAML is optional and gracefully skipped if absent.
+# Dependabot scans this file to surface any future pip dependencies.
+# No external packages are required at this time.


### PR DESCRIPTION
- Extend .github/dependabot.yml with pip ecosystem for /personal-wiki
- Add npm groups to merge minor/patch production and dev dependency updates
- Add commit-message prefix and scope for cleaner changelogs
- Create personal-wiki/requirements.txt to declare no external pip deps

Verification: npm test pass, tsc pass, build pass (with DATABASE_URL). No secrets leaked in dependabot config.

task-id: cmqqb0ddq00080jnsxuwdqoa5